### PR TITLE
MemoryMappedFile利用時に複数のMeCabTaggerを生成できるよう修正

### DIFF
--- a/MeCab.DotNet.Tests/MeCab.DotNet.Tests.csproj
+++ b/MeCab.DotNet.Tests/MeCab.DotNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <RootNamespace>MeCab</RootNamespace>
 
     <DebugType>pdbonly</DebugType>
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MeCab.DotNet.Tests/MeCabTaggerTest.cs
+++ b/MeCab.DotNet.Tests/MeCabTaggerTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace MeCab
+{
+    [TestFixture]
+    public class MeCabTaggerTest
+    {
+#if NET45
+        /// <summary>
+        /// 複数個のインスタンスを作っても例外が発生しないことの確認。
+        /// 従来、MemoryMappedFileに起因して、辞書が使用中という旨のIOExceptionが発生していた。
+        /// </summary>
+        [Test]
+        public void CreateMulti()
+        {
+            using var tagger1 = MeCabTagger.Create();
+            using var tagger2 = MeCabTagger.Create();
+
+            GC.KeepAlive(tagger1);
+            GC.KeepAlive(tagger2);
+        }
+#endif
+    }
+}

--- a/MeCab.DotNet.Tests/MeCabTaggerTest.cs
+++ b/MeCab.DotNet.Tests/MeCabTaggerTest.cs
@@ -6,10 +6,10 @@ namespace MeCab
     [TestFixture]
     public class MeCabTaggerTest
     {
-#if NET45
         /// <summary>
         /// 複数個のインスタンスを作っても例外が発生しないことの確認。
         /// 従来、MemoryMappedFileに起因して、辞書が使用中という旨のIOExceptionが発生していた。
+        /// net45はMemoryMappedFileを利用するので確認可能。netcoreapp2.1は元々利用しないので従来から成功する。
         /// </summary>
         [Test]
         public void CreateMulti()
@@ -20,6 +20,5 @@ namespace MeCab
             GC.KeepAlive(tagger1);
             GC.KeepAlive(tagger2);
         }
-#endif
     }
 }

--- a/MeCab.DotNet/Core/MeCabDictionary.cs
+++ b/MeCab.DotNet/Core/MeCabDictionary.cs
@@ -136,7 +136,7 @@ namespace MeCab.Core
             }
         }
 #else
-            public void Open(string filePath)
+        public void Open(string filePath)
         {
             this.FileName = filePath;
             

--- a/MeCab.DotNet/Core/MeCabDictionary.cs
+++ b/MeCab.DotNet/Core/MeCabDictionary.cs
@@ -23,6 +23,7 @@ namespace MeCab.Core
         private MemoryMappedFile mmf;
         private MemoryMappedViewAccessor tokens;
         private MemoryMappedViewAccessor features;
+        private FileStream fileStream;
 #else
         private Token[] tokens;
         private byte[] features;
@@ -74,8 +75,27 @@ namespace MeCab.Core
 #if NET40 || NET45 || NETSTANDARD2_0 || NETSTANDARD2_1
         public void Open(string filePath)
         {
-            this.mmf = MemoryMappedFile.CreateFromFile(filePath, FileMode.Open,
-                                                       null, 0L, MemoryMappedFileAccess.Read);
+            // https://github.com/komutan/NMeCab/blob/4d61926834b4a63e38cee050c0b7382c52a71226/src/LibNMeCab/Core/MemoryMappedFileLoader.cs#L28
+            this.fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+#if NET40 || NET45
+            this.mmf = MemoryMappedFile.CreateFromFile(
+                fileStream,
+                null,
+                0L,
+                MemoryMappedFileAccess.Read,
+                null,
+                HandleInheritability.None,
+                false);
+#else
+            this.mmf = MemoryMappedFile.CreateFromFile(
+                fileStream,
+                null,
+                0L,
+                MemoryMappedFileAccess.Read,
+                HandleInheritability.None,
+                false);
+#endif
             this.Open(this.mmf, filePath);
         }
 
@@ -116,7 +136,7 @@ namespace MeCab.Core
             }
         }
 #else
-        public void Open(string filePath)
+            public void Open(string filePath)
         {
             this.FileName = filePath;
             
@@ -270,6 +290,7 @@ namespace MeCab.Core
                 if (this.mmf != null) this.mmf.Dispose();
                 if (this.tokens != null) this.tokens.Dispose();
                 if (this.features != null) this.features.Dispose();
+                this.fileStream?.Dispose();
 #endif
             }
 


### PR DESCRIPTION
大変便利に使わせていただいております。ありがとうございます。

この差分では、ファイル名ではなく`FileStream`を元に`MemoryMappedFile`を生成するようにしています。 https://github.com/komutan/NMeCab での実装を参考にしています。
> https://github.com/komutan/NMeCab/blob/4d61926834b4a63e38cee050c0b7382c52a71226/src/LibNMeCab/Core/MemoryMappedFileLoader.cs#L28

よろしくお願い致します。