### PR TITLE
AppContext instead of Assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,12 @@ jobs:
       with:
         dotnet-version: 5.0.100
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore MeCab.Dotnet/MeCab.Dotnet.csproj
+    - name: Install dependencies (Tests)
+      run: dotnet restore MeCab.Dotnet.Tests/MeCab.Dotnet.Tests.csproj
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore MeCab.Dotnet/MeCab.Dotnet.csproj
+    - name: Build (Test)
+      run: dotnet build --configuration Release --no-restore MeCab.Dotnet.Tests/MeCab.Dotnet.Tests.csproj
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal MeCab.Dotnet.Tests/MeCab.Dotnet.Tests.csproj

--- a/MeCab.DotNet/MeCabParam.cs
+++ b/MeCab.DotNet/MeCabParam.cs
@@ -87,8 +87,7 @@ namespace MeCab
 
 #if !NETSTANDARD1_3
             // In unit test context, the current folder path is set unstable.
-            var assemblyFolderPath = Path.GetDirectoryName(
-                this.GetType().Assembly.Location);
+            var assemblyFolderPath = AppContext.BaseDirectory;
             var inPackagePath = CombinePath(assemblyFolderPath!, "..", "InPackage");
             var dicdir = File.Exists(inPackagePath) ?
                 CombinePath(assemblyFolderPath, "..", "..", "content", "dic") :

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,9 +10,11 @@
 
 # これは何？
 
+NOTE: 将来的に、MeCab.DotNetとNMeCabを統合する作業をしています。 [詳しくはこのissueを参照して下さい。](https://github.com/kekyo/MeCab.DotNet/issues/5)
+
 ["MeCab"](https://github.com/taku910/mecab) は、日本語形態素解析エンジンのプロジェクトです。
 
-["NMeCab"](https://ja.osdn.net/projects/nmecab/) は、上記MeCabを、.NET Framework 2.0のマネージライブラリとして実装し直したものです。ただ、もう更新されていないようです...
+["NMeCab"](https://ja.osdn.net/projects/nmecab/) は、上記MeCabを、.NET Framework 2.0のマネージライブラリとして実装し直したものです。ただ、もう更新されていないようです...  --> [GitHubで復活しました](https://github.com/komutan/NMeCab)
 
 "MeCab.DotNet" （このプロジェクト）は、上記NMeCabを最新の.NET Core 1/2/3と.NET Frameworkで使えるように移植し、NuGetのパッケージに固めて使いやすくしたものです。
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ A Japanese language morphological analysis engine for .NET Core.
 
 # What's this?
 
+NOTE: We will merge both MeCab.DotNet and NMeCab in future release. [See related issue.](https://github.com/kekyo/MeCab.DotNet/issues/5)
+
 ["MeCab"](https://github.com/taku910/mecab) is a Japanese language morphological analysis engine.
 
-["NMeCab"](https://ja.osdn.net/projects/nmecab/) is a re-implementation of MeCab engine on .NET Framework 2.0 managed library, but didn't update long time (looks like suspended...)
+["NMeCab"](https://ja.osdn.net/projects/nmecab/) is a re-implementation of MeCab engine on .NET Framework 2.0 managed library, but didn't update long time (looks like suspended...) --> [Revived here (GitHub)](https://github.com/komutan/NMeCab)
 
 "MeCab.DotNet" (this project) is a ported of NMeCab on .NET Core 1/2/3 and .NET Frameworks and packed into NuGet format.
 


### PR DESCRIPTION
https://github.com/kekyo/MeCab.DotNet/issues/8
`AppContext.BaseDirectory` に変えたらどうですか、私のパソコンでは正常に動きます。
AOT も使えよになりました。
宜しければ、新しnugetパケッジもお願いします。MeCab.DotNet 大変助かりました！